### PR TITLE
Add fish support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Features
 Requirements
 ------------
 
--  Bash
+-  Bash or Fish
 
 Install
 -------
@@ -41,6 +41,12 @@ Import your existing shell history:
 ::
 
     HISTTIMEFORMAT='%s ' history | duiker import -
+
+or in Fish:
+
+::
+    history --show-time="%s " | duiker import -s fish -
+
 
 Configuration
 -------------
@@ -89,7 +95,7 @@ You can use any ``MATCH`` [#]_ expression to search the database:
 Limitations
 -----------
 
-Duiker only supports Bash at present. Pull requests for other shells
+Duiker only supports Bash and Fish at present. Pull requests for other shells
 welcome.
 
 License

--- a/src/cli.yaml
+++ b/src/cli.yaml
@@ -22,6 +22,11 @@ subcommands:
           - input:
               index: 1
               required: true
+          - shell:
+              required: false
+              default_value: bash
+              short: s
+              long: shell
     - log:
         about: Show commands from all time.
     - magic:
@@ -51,6 +56,25 @@ subcommands:
               __duiker_import
               __do_something_else
             }
+          
+          FISH SHELL
+          For fish shell, add the completion to your fish config
+          using the following:
+            
+            duiker magic --shell fish >> ~/.config/fish/config.fish
+
+          Then source your config value to your current session:
+            source ~/.config/fish/config.fish
+        args:
+            - shell:
+                required: false
+                short: s
+                long: shell
+                default_value: bash
+                takes_value: true
+                possible_values:
+                    - bash
+                    - fish
     - search:
         about: Search for a command in the history database.
         args:

--- a/src/magic.fish
+++ b/src/magic.fish
@@ -1,0 +1,3 @@
+function __duiker_import --on-event fish_prompt
+    history --show-time="%s " | grep -v 'history ' | head -n1 | duiker import --shell fish --quiet -
+end

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,8 +96,12 @@ pub fn dispatch_command(matches: clap::ArgMatches) {
                 output_commands(&commands);
             };
         }
-        ("magic", Some(_)) => {
-            commands::magic();
+        ("magic", Some(m)) => {
+            if let Some(shell) = m.value_of("shell") {
+                commands::magic(shell);
+            } else {
+                commands::magic("bash");
+            }
         }
         ("search", Some(m)) => {
             let expression = m.value_of("expression").unwrap();


### PR DESCRIPTION
Adds Fish shell history support. Tried to make this as non-breaking as possible. If no shell is provided, it defaults to bash.
`parse_history_line` regex should work for both regardless of flag, so I can remove the flag if necessary.

Also added some tests.